### PR TITLE
fixing error caused by oudated database field name

### DIFF
--- a/WarehousePilot_app/backend/inventory/views.py
+++ b/WarehousePilot_app/backend/inventory/views.py
@@ -50,11 +50,11 @@ def get_inventory(request):
             qty = item['qty']
             if qty == 0:
                 item['status'] = 'Out of Stock'
-                logger.warning("get_inventory - Item %s is out of stock", item['sku_color'])
+                logger.info(f"get_inventory - Item {item['sku_color_id']} is out of stock")
             elif qty < 50:
                 item['status'] = 'Low'
                 low_stock_items.append(item)
-                logger.warning("get_inventory - Item %s is in low stock", item['sku_color'])
+                logger.info(f"get_inventory - Item {item['sku_color_id']} is in low stock")
                 # send_alert(item)
             elif 50 <= qty <= 100:
                 item['status'] = 'Moderate'

--- a/WarehousePilot_app/backend/orders/views.py
+++ b/WarehousePilot_app/backend/orders/views.py
@@ -315,7 +315,7 @@ class InventoryPicklistItemsView(APIView):
                 status=status.HTTP_404_NOT_FOUND
             )
         except InventoryPicklist.DoesNotExist:
-            logger.error("Picklist could not be found for order %s (InventoryPicklistItemsView)", picklist.picklist_id)
+            logger.error("Picklist could not be found for order %s (InventoryPicklistItemsView)", order_id)
             return Response(
                 {"error": "No picklist found for the given order"},
                 status=status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
**Bug**: Two log messages were failing the database retrieval for the inventory page.
- **Actual problem**: An outdated database field name was used when trying to retrieve the ID which was throwing the user
- **Solution**: Replace outdated field with current name