### PR TITLE
Qa manufacturing list

### DIFF
--- a/WarehousePilot_app/backend/qa_dashboard/urls.py
+++ b/WarehousePilot_app/backend/qa_dashboard/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import QADashboardView, QAManufacturingTasksView, UpdateQATaskView, ReportQAErrorView, UpdateQAStatusView
+from .views import QADashboardView, QAManufacturingTasksView, UpdateQATaskView, ReportQAErrorView, UpdateQAStatusView, QAErrorListView
 
 urlpatterns = [
     path('', QADashboardView.as_view(), name='qa_dashboard'),
@@ -7,4 +7,5 @@ urlpatterns = [
     path('qa_tasks/update/', UpdateQATaskView.as_view(), name='update_qa_task'),
     path('qa_tasks/report_error/', ReportQAErrorView.as_view(), name='report_qa_error'),
     path('qa_tasks/update_status/', UpdateQAStatusView.as_view(), name='update_qa_status'),
+    path('qa_tasks/error_reports/', QAErrorListView.as_view(), name='qa-error-reports'),
 ]

--- a/WarehousePilot_app/backend/qa_dashboard/views.py
+++ b/WarehousePilot_app/backend/qa_dashboard/views.py
@@ -10,6 +10,7 @@ import logging
 
 logger = logging.getLogger('WarehousePilot_app')
 
+
 class QADashboardView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
@@ -20,23 +21,27 @@ class QADashboardView(APIView):
 
 
 class QAManufacturingTasksView(APIView):
+    """
+    Fetches manufacturing tasks assigned to the QA user.
+    """
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
         try:
             user = request.user
-            logger.debug(f"User type: {type(user)}")  # Debugging
+            logger.debug(f"User type: {type(user)}")
             logger.debug(f"User attributes: {dir(user)}")
             logger.debug(f"User role: {getattr(user, 'role', 'No role attribute found')}")
             logger.debug(f"User ID: {user.user_id}")
 
-            # Check if the user is indeed QA
+            # Check if the user is QA
             if not hasattr(user, 'role') or getattr(user, 'role', '').lower() != 'qa':
                 logger.error("Unauthorized access - User is not a QA employee (QAManufacturingTasksView)")
                 return Response({"error": "Unauthorized: User is not a QA staff member."},
                                 status=status.HTTP_403_FORBIDDEN)
 
+            # Get tasks where the user is assigned as production QA or paint QA
             tasks = ManufacturingTask.objects.filter(
                 Q(prod_qa_employee_id=user.user_id) |
                 Q(paint_qa_employee_id=user.user_id)
@@ -56,13 +61,18 @@ class QAManufacturingTasksView(APIView):
 
             logger.info("Successfully retrieved all tasks associated with QA staff member %s", user.user_id)
             return Response(response_data, status=status.HTTP_200_OK)
+
         except Exception as e:
-            logger.error("Failed to retrieve task associated with QA staff member %s", user.user_id)
+            logger.error("Failed to retrieve task associated with QA staff member %s. Error: %s", user.user_id, str(e))
             return Response({"error": "An unexpected error occurred."},
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class UpdateQATaskView(APIView):
+    """
+    Allows a QA user to update the QA status of a manufacturing task
+    (prod_qa or paint_qa to 'Completed' or 'Pending').
+    """
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
@@ -82,7 +92,7 @@ class UpdateQATaskView(APIView):
             if paint_qa in ["Completed", "Pending"]:
                 task.paint_qa = (paint_qa == "Completed")
 
-            # If both QA are completed, set status to Completed; otherwise In Progress
+            # If both QA steps are completed, set status to Completed; otherwise In Progress
             if task.prod_qa and task.paint_qa:
                 task.status = 'Completed'
             else:
@@ -99,12 +109,15 @@ class UpdateQATaskView(APIView):
             return Response({"error": "Task not found."},
                             status=status.HTTP_404_NOT_FOUND)
         except Exception as e:
-            logger.error("Failed to update status of manufacturing task %s (UpdateQATaskView)", task_id)
+            logger.error("Failed to update status of manufacturing task %s (UpdateQATaskView): %s", task_id, str(e))
             return Response({"error": f"An error occurred: {str(e)}"},
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class ReportQAErrorView(APIView):
+    """
+    Allows a QA user to report a QA error for a manufacturing task (sets task.status to 'Error').
+    """
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
@@ -141,6 +154,9 @@ class ReportQAErrorView(APIView):
 
 
 class UpdateQAStatusView(APIView):
+    """
+    Allows a QA user to update a task from 'Error' back to 'In Progress' (or another status).
+    """
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
@@ -174,7 +190,53 @@ class UpdateQAStatusView(APIView):
             return Response({"error": "Task not found."},
                             status=status.HTTP_404_NOT_FOUND)
         except Exception as e:
-            logger.error("Failed to update manufacturing task status (UpdateQAStatusView)")
+            logger.error("Failed to update manufacturing task status (UpdateQAStatusView): %s", str(e))
             return Response({"error": f"An error occurred: {str(e)}"},
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+
+class QAErrorListView(APIView):
+    """
+    Retrieves a list of all QAErrorReport entries (and related ManufacturingTask info).
+    Accessible by QA staff and managers.
+    """
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        try:
+            user = request.user
+            user_role = getattr(user, 'role', '').lower()
+
+            # Allow both QA and Manager
+            if user_role not in ['qa', 'manager']:
+                logger.error("Unauthorized access - User is neither QA nor Manager (QAErrorListView)")
+                return Response(
+                    {"error": "Unauthorized: User must be QA or a Manager."},
+                    status=status.HTTP_403_FORBIDDEN
+                )
+
+            # Retrieve all QA error reports
+            errors = QAErrorReport.objects.select_related('manufacturing_task', 'reported_by').all()
+
+            response_data = []
+            for error in errors:
+                response_data.append({
+                    "id": error.id,
+                    "subject": error.subject,
+                    "comment": error.comment,
+                    "created_at": error.created_at.isoformat(),
+                    "manufacturing_task_id": error.manufacturing_task.manufacturing_task_id,
+                    "task_status": error.manufacturing_task.status,
+                    "sku_color_id": getattr(error.manufacturing_task, 'sku_color_id', None),
+                    "reported_by": getattr(error.reported_by, 'username', 'N/A'),
+                })
+
+            return Response(response_data, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            logger.error(f"Failed to retrieve QA error reports: {str(e)}")
+            return Response(
+                {"error": "An unexpected error occurred while fetching QA error reports."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )

--- a/WarehousePilot_app/frontend/src/components/dashboard_sidebar1/sidebar-items.tsx
+++ b/WarehousePilot_app/frontend/src/components/dashboard_sidebar1/sidebar-items.tsx
@@ -52,6 +52,17 @@ return [
     title: "QA Tasks",
   },] : [])
   ,
+  ...(userRole === "qa" || userRole === "manager"
+  ? [
+      {
+        key: "qa_error_reports",
+        href: "/qa_error_list_view",
+        icon: "heroicons-outline:exclamation-circle", // ⚠️ New Exclamation Circle Icon
+        title: "QA Error Reports",
+      },
+    ]
+  : []),
+
   ...(userRole === 'staff' ? [{
     key: "assigned_picklist",
     href: "/assigned_picklist",

--- a/WarehousePilot_app/frontend/src/components/orders/QAErrorListview.jsx
+++ b/WarehousePilot_app/frontend/src/components/orders/QAErrorListview.jsx
@@ -1,0 +1,165 @@
+import React, { useState, useEffect, useMemo } from "react";
+import {
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  Input,
+  Pagination,
+} from "@nextui-org/react";
+import { SearchIcon } from "@nextui-org/shared-icons";
+import axios from "axios";
+import SideBar from "../dashboard_sidebar1/App";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const QAErrorListView = () => {
+  const [filterValue, setFilterValue] = useState("");
+  const [errors, setErrors] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState(null);
+  const [page, setPage] = useState(1);
+  const rowsPerPage = 10;
+
+  useEffect(() => {
+    const fetchQAErrors = async () => {
+      try {
+        const token = localStorage.getItem("token");
+        if (!token) {
+          setErrorMsg("No authorization token found");
+          setLoading(false);
+          return;
+        }
+        const response = await axios.get(
+          `${API_BASE_URL}/qa_dashboard/qa_tasks/error_reports/`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        );
+        setErrors(response.data);
+        setLoading(false);
+      } catch (err) {
+        console.error("Error fetching QA errors:", err);
+        setErrorMsg("Failed to fetch QA errors");
+        setLoading(false);
+      }
+    };
+
+    fetchQAErrors();
+  }, []);
+
+  const filteredErrors = useMemo(() => {
+    if (!filterValue.trim()) return errors;
+    const searchTerm = filterValue.toLowerCase();
+    return errors.filter((err) =>
+      [err.subject, err.comment, err.manufacturing_task_id?.toString()]
+        .some((value) => value?.toLowerCase().includes(searchTerm))
+    );
+  }, [errors, filterValue]);
+
+  const startIndex = (page - 1) * rowsPerPage;
+  const endIndex = startIndex + rowsPerPage;
+  const paginatedErrors = filteredErrors.slice(startIndex, endIndex);
+  const totalPages = Math.ceil(filteredErrors.length / rowsPerPage);
+
+  return (
+    <div className="flex h-full">
+      {/* Sidebar */}
+      <SideBar />
+
+      {/* Main Content */}
+      <div className="flex-1">
+        <div className="mt-16 p-8">
+          <div className="flex flex-col gap-6">
+            {/* Title on Separate Line */}
+            <div>
+              <h1 className="text-2xl font-bold mb-6">QA Error Reports</h1>
+            </div>
+
+            {/* Error Message */}
+            {errorMsg && (
+              <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+                {errorMsg}
+              </div>
+            )}
+
+            {/* Search Bar */}
+            <Input
+              size="md"
+              placeholder="Search QA errors..."
+              value={filterValue}
+              onChange={(e) => setFilterValue(e.target.value)}
+              endContent={<SearchIcon className="text-default-400" width={16} />}
+              className="w-72 mb-4"
+            />
+
+            {/* Table Data */}
+            {loading ? (
+              <div className="flex justify-center items-center h-64">
+                <div>Loading...</div>
+              </div>
+            ) : (
+              <>
+                <Table aria-label="QA Error list" className="min-w-full">
+                  <TableHeader>
+                    <TableColumn>ID</TableColumn>
+                    <TableColumn>Subject</TableColumn>
+                    <TableColumn>Comment</TableColumn>
+                    <TableColumn>Task ID</TableColumn>
+                    <TableColumn>Task Status</TableColumn>
+                    <TableColumn>Reported By</TableColumn>
+                    <TableColumn>Created At</TableColumn>
+                  </TableHeader>
+                  <TableBody items={paginatedErrors}>
+                    {(item) => (
+                      <TableRow key={item.id}>
+                        <TableCell>{item.id}</TableCell>
+                        <TableCell>{item.subject}</TableCell>
+                        <TableCell>{item.comment}</TableCell>
+                        <TableCell>{item.manufacturing_task_id}</TableCell>
+                        <TableCell>{item.task_status}</TableCell>
+                        <TableCell>{item.reported_by}</TableCell>
+                        <TableCell>
+                          {dayjs.utc(item.created_at)
+                            .tz("America/Toronto")
+                            .format("YYYY-MM-DD HH:mm")}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+
+                {/* Pagination */}
+                <div className="flex justify-between items-center mt-4">
+                  <span>
+                    Page {page} of {totalPages}
+                  </span>
+                  <Pagination
+                    total={totalPages}
+                    page={page}
+                    initialPage={1}
+                    onChange={(newPage) => setPage(newPage)}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QAErrorListView;
+
+
+
+

--- a/WarehousePilot_app/frontend/src/components/orders/QAtasks.jsx
+++ b/WarehousePilot_app/frontend/src/components/orders/QAtasks.jsx
@@ -272,7 +272,7 @@ const QATasks = () => {
                 }
               }}
             >
-              Error Fixed
+              Error Reported
             </Button>
           )}
         </div>

--- a/WarehousePilot_app/frontend/src/components/routes/dashboard_routes.jsx
+++ b/WarehousePilot_app/frontend/src/components/routes/dashboard_routes.jsx
@@ -15,6 +15,7 @@ import ManufacturingListItem from '../orders/ManufacturingListItem';
 import QATasks from '../orders/QAtasks';
 import StaffManufacturingTasks from '../manufacturing/StaffManufacturingTasks';
 import ManuTasksTable from '../manufacturing/ManufacturingTasks/manu-tasks/App';
+import QAErrorListView from '../orders/QAErrorListview';
 
 import React from 'react';
 import { Navigate } from 'react-router-dom';
@@ -47,6 +48,9 @@ export const dashboard_routes = [
   { path: '/qa_tasks', element: <ProtectedRoute element={<QATasks />} /> },
   { path: '/staff_manufacturing_tasks', element: <ProtectedRoute element={<StaffManufacturingTasks />} /> }, 
   { path: '/manufacturing_tasks', element: <ProtectedRoute element={<ManuTasksTable />} /> },
+  { path: '/qa_error_list_view', element: <ProtectedRoute element={<QAErrorListView />} /> },
+  
+
 
 ];
 


### PR DESCRIPTION
This merge adds a **QA Error Reports** page, integrating both frontend and backend functionality to allow QA users and managers to track and manage QA errors. Includes: #95 #154
- Backend API for retrieving QA error reports.
- Frontend page for displaying errors in a table.
- Sidebar navigation update to include the QA Error Reports page for QA and managers.
- Dashboard routing fixes for proper navigation.

Future Improvements 
- **Allow Managers to Remove Fixed Errors:**  
  - Add an API and UI option for managers to mark errors as "resolved" and remove them from the table.
-  **Filtering**  
   - Allow filtering by **task ID, reported date**, and **status**.
- **Notifications for New Errors:**  
  - Send alerts to managers when new QA errors are reported.
