### PR TITLE
Add Endpoint and UI for Managers to Resolve QA Errors

### DIFF
--- a/WarehousePilot_app/backend/qa_dashboard/urls.py
+++ b/WarehousePilot_app/backend/qa_dashboard/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
-from .views import QADashboardView, QAManufacturingTasksView, UpdateQATaskView, ReportQAErrorView, UpdateQAStatusView, QAErrorListView
+from .views import QADashboardView, QAManufacturingTasksView, UpdateQATaskView, ReportQAErrorView, UpdateQAStatusView, QAErrorListView, ResolveQAErrorView
+
 
 urlpatterns = [
     path('', QADashboardView.as_view(), name='qa_dashboard'),
@@ -8,4 +9,6 @@ urlpatterns = [
     path('qa_tasks/report_error/', ReportQAErrorView.as_view(), name='report_qa_error'),
     path('qa_tasks/update_status/', UpdateQAStatusView.as_view(), name='update_qa_status'),
     path('qa_tasks/error_reports/', QAErrorListView.as_view(), name='qa-error-reports'),
+    path('qa_tasks/error_reports/resolve/', ResolveQAErrorView.as_view(), name='resolve-qa-error'),
+    
 ]

--- a/WarehousePilot_app/frontend/src/components/orders/QAErrorListview.jsx
+++ b/WarehousePilot_app/frontend/src/components/orders/QAErrorListview.jsx
@@ -8,6 +8,7 @@ import {
   TableCell,
   Input,
   Pagination,
+  Button,
 } from "@nextui-org/react";
 import { SearchIcon } from "@nextui-org/shared-icons";
 import axios from "axios";
@@ -38,17 +39,25 @@ const QAErrorListView = () => {
           setLoading(false);
           return;
         }
+
         const response = await axios.get(
           `${API_BASE_URL}/qa_dashboard/qa_tasks/error_reports/`,
           {
             headers: { Authorization: `Bearer ${token}` },
           }
         );
-        setErrors(response.data);
-        setLoading(false);
+        
+        // If server returns an array, set errors. Otherwise it's likely an error object.
+        if (Array.isArray(response.data)) {
+          setErrors(response.data);
+        } else {
+          setErrorMsg(response.data.error || "Failed to fetch QA errors");
+        }
+
       } catch (err) {
         console.error("Error fetching QA errors:", err);
         setErrorMsg("Failed to fetch QA errors");
+      } finally {
         setLoading(false);
       }
     };
@@ -56,15 +65,50 @@ const QAErrorListView = () => {
     fetchQAErrors();
   }, []);
 
+  const handleResolveError = async (errorId) => {
+    if (!window.confirm("Are you sure you want to mark this error as resolved?")) {
+      return;
+    }
+
+    try {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        alert("No authorization token found");
+        return;
+      }
+
+      await axios.post(
+        `${API_BASE_URL}/qa_dashboard/qa_tasks/error_reports/resolve/`,
+        { error_id: errorId },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+
+      // Remove the resolved error from the table
+      setErrors((prev) => prev.filter((err) => err.id !== errorId));
+      alert("Error resolved and removed.");
+    } catch (err) {
+      console.error("Error resolving QA error:", err);
+      if (err.response?.status === 403) {
+        // For example, if the backend says only managers can do this
+        alert("You are not authorized to resolve errors.");
+      } else {
+        alert("Failed to resolve the error. Check console for details.");
+      }
+    }
+  };
+
+  // Filtering logic
   const filteredErrors = useMemo(() => {
     if (!filterValue.trim()) return errors;
     const searchTerm = filterValue.toLowerCase();
     return errors.filter((err) =>
-      [err.subject, err.comment, err.manufacturing_task_id?.toString()]
-        .some((value) => value?.toLowerCase().includes(searchTerm))
+      [err.subject, err.comment, err.manufacturing_task_id?.toString()].some((value) =>
+        value?.toLowerCase().includes(searchTerm)
+      )
     );
   }, [errors, filterValue]);
 
+  // Pagination
   const startIndex = (page - 1) * rowsPerPage;
   const endIndex = startIndex + rowsPerPage;
   const paginatedErrors = filteredErrors.slice(startIndex, endIndex);
@@ -72,26 +116,19 @@ const QAErrorListView = () => {
 
   return (
     <div className="flex h-full">
-      {/* Sidebar */}
       <SideBar />
 
-      {/* Main Content */}
       <div className="flex-1">
         <div className="mt-16 p-8">
           <div className="flex flex-col gap-6">
-            {/* Title on Separate Line */}
-            <div>
-              <h1 className="text-2xl font-bold mb-6">QA Error Reports</h1>
-            </div>
+            <h1 className="text-2xl font-bold mb-6">QA Error Reports</h1>
 
-            {/* Error Message */}
             {errorMsg && (
               <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
                 {errorMsg}
               </div>
             )}
 
-            {/* Search Bar */}
             <Input
               size="md"
               placeholder="Search QA errors..."
@@ -101,7 +138,6 @@ const QAErrorListView = () => {
               className="w-72 mb-4"
             />
 
-            {/* Table Data */}
             {loading ? (
               <div className="flex justify-center items-center h-64">
                 <div>Loading...</div>
@@ -117,6 +153,9 @@ const QAErrorListView = () => {
                     <TableColumn>Task Status</TableColumn>
                     <TableColumn>Reported By</TableColumn>
                     <TableColumn>Created At</TableColumn>
+                    {/* Everyone can see the "Resolve" button,
+                        but only managers pass the backend check */}
+                    <TableColumn>Actions</TableColumn>
                   </TableHeader>
                   <TableBody items={paginatedErrors}>
                     {(item) => (
@@ -132,12 +171,21 @@ const QAErrorListView = () => {
                             .tz("America/Toronto")
                             .format("YYYY-MM-DD HH:mm")}
                         </TableCell>
+                        <TableCell>
+                          <Button
+                            size="sm"
+                            color="primary"
+                            variant="flat"
+                            onClick={() => handleResolveError(item.id)}
+                          >
+                            Resolve
+                          </Button>
+                        </TableCell>
                       </TableRow>
                     )}
                   </TableBody>
                 </Table>
 
-                {/* Pagination */}
                 <div className="flex justify-between items-center mt-4">
                   <span>
                     Page {page} of {totalPages}
@@ -159,6 +207,7 @@ const QAErrorListView = () => {
 };
 
 export default QAErrorListView;
+
 
 
 


### PR DESCRIPTION
This merge request adds a new endpoint and UI functionality to allow managers to resolve QA errors.  #95 
- Added `ResolveQAErrorView` in `views.py` to remove error reports that have been resolved (manager-only access).
- Registered the new route in `urls.py`.
- Updated `QAErrorListView.jsx` to include a “Resolve” button calling the new endpoint.

