### PR TITLE
Quick UI update for loading screens

### DIFF
--- a/WarehousePilot_app/frontend/src/components/inventory-stock/App.tsx
+++ b/WarehousePilot_app/frontend/src/components/inventory-stock/App.tsx
@@ -4,6 +4,7 @@ import SideBar from "../dashboard_sidebar1/App";
 import type {Selection, SortDescriptor} from "@heroui/react";
 import type {ColumnsKey, Inventory, StatusOptions} from "./data";
 import type {Key} from "@react-types/shared";
+import { Spinner } from "@heroui/spinner";
 
 import {
   Dropdown,
@@ -507,7 +508,9 @@ export default function InventoryTable() {
   }, [filterSelectedKeys, page, pages, filteredItems.length, onPreviousPage, onNextPage]);
 
   if (loading) {
-    return <div className="loading-container">Loading... This may take a minute</div>;
+    return <div className="loading-container">Loading... This may take a minute
+    <Spinner size="lg" color="default" className="ms-5"/>
+    </div>;
   }
 
   return (

--- a/WarehousePilot_app/frontend/src/components/manufacturing/ManufacturingTasks/manu-tasks/App.tsx
+++ b/WarehousePilot_app/frontend/src/components/manufacturing/ManufacturingTasks/manu-tasks/App.tsx
@@ -4,6 +4,8 @@ import SideBar from "../../../dashboard_sidebar1/App";
 import type {Selection, SortDescriptor} from "@heroui/react";
 import type {ColumnsKey, ManufacturingTask} from "./data";
 import type {Key} from "@react-types/shared";
+import { Spinner } from "@heroui/spinner";
+
 
 import {
   Dropdown,
@@ -461,7 +463,9 @@ export default function ManuTasksTable() {
   }, [filterSelectedKeys, page, pages, filteredItems.length, onPreviousPage, onNextPage]);
 
   if (loading) {
-    return <div className="loading-container">Loading... This may take a minute</div>;
+    return <div className="loading-container">Loading... This may take a minute
+    <Spinner size="lg" color="default" className="ms-5"/>
+    </div>;
   }
 
   return (

--- a/WarehousePilot_app/frontend/src/components/orders/OrderListView.jsx
+++ b/WarehousePilot_app/frontend/src/components/orders/OrderListView.jsx
@@ -26,6 +26,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import NavBar from "../navbar/App";
+import { Spinner } from "@heroui/spinner";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 // Extend dayjs with UTC and timezone
@@ -338,7 +339,9 @@ const OrderListView = () => {
 
       {loading ? (
         <div className="flex justify-center items-center h-64">
-          <div>Loading...</div>
+          <div>Loading...
+          <Spinner size="lg" color="default" className="ms-5"/>
+          </div>
         </div>
       ) : (
         <>


### PR DESCRIPTION
- Just a quick UI update for loading screens, added the spinner to match the picklists page. Static text looked like app was bugging, especially on long fetch times like manufacturing tasks. 