### PR TITLE
3.3-throughput_backend

### DIFF
--- a/WarehousePilot_app/backend/kpi_dashboard/urls.py
+++ b/WarehousePilot_app/backend/kpi_dashboard/urls.py
@@ -1,14 +1,15 @@
 from django.urls import path
 from . import views
-from .views import daily_picks_data, daily_picks_details, order_fulfillment_rate
+from .views import daily_picks_data, daily_picks_details, order_fulfillment_rate, ThroughputView
 
 urlpatterns = [
     path('order-picking-accuracy/', views.order_picking_accuracy, name='order_picking_accuracy'),
     path('order-picking-daily-stats/', daily_picks_data, name='daily_picks_data'),
     path('order-picking-daily-details/', daily_picks_details, name='daily_picks_details'),
-    path('order-fulfillment-rate/', order_fulfillment_rate, name='order_fulfillment_rate'),  # New endpoint
-    path('active-orders/', views.ActiveOrdersView.as_view(), name='active_orders'),  # New endpoint
+    path('order-fulfillment-rate/', order_fulfillment_rate, name='order_fulfillment_rate'),  
+    path('active-orders/', views.ActiveOrdersView.as_view(), name='active_orders'),  
     path('completed-orders/', views.CompletedOrdersView.as_view(), name='completed_orders'), 
     path('active-orders-details/', views.ActiveOrdersDetailsView.as_view(), name='active_orders_details'),
+    path('throughput-threshold/', views.ThroughputView.as_view(), name='throughput_threshold'), 
 
 ]

--- a/WarehousePilot_app/frontend/package-lock.json
+++ b/WarehousePilot_app/frontend/package-lock.json
@@ -20,6 +20,7 @@
             "@mui/x-data-grid": "^7.23.5",
             "axios": "^1.7.7",
             "chart.js": "^4.4.7",
+            "data-fns": "^1.1.0",
             "date-fns": "^4.1.0",
             "dayjs": "^1.11.13",
             "framer-motion": "^12.4.7",
@@ -8459,6 +8460,18 @@
             "node": ">=12"
          }
       },
+      "node_modules/data-fns": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/data-fns/-/data-fns-1.1.0.tgz",
+         "integrity": "sha512-/rJzdbnuY3DVgzqsfEfc+tJLuAKYaHzkUxSMRIU3dxKFeWGD/MGhrgAfuwSOmgfJ8enygztp9DeuvoSxauppIg==",
+         "license": "MIT",
+         "dependencies": {
+            "unit-fns": "^0.1.6"
+         },
+         "engines": {
+            "node": ">=10"
+         }
+      },
       "node_modules/data-urls": {
          "version": "3.0.2",
          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -13192,6 +13205,15 @@
          "dev": true,
          "engines": {
             "node": ">=4"
+         }
+      },
+      "node_modules/unit-fns": {
+         "version": "0.1.9",
+         "resolved": "https://registry.npmjs.org/unit-fns/-/unit-fns-0.1.9.tgz",
+         "integrity": "sha512-bxceIkc7n2icQmgQx8u3vX98ZBIcpL2YJDKIsWDFK7ZX1TTuLvtNWVNd9/oARCDHd7QQRzwc+zxabO0HSK8X0w==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=10"
          }
       },
       "node_modules/universalify": {

--- a/WarehousePilot_app/frontend/package.json
+++ b/WarehousePilot_app/frontend/package.json
@@ -23,6 +23,7 @@
       "@mui/x-data-grid": "^7.23.5",
       "axios": "^1.7.7",
       "chart.js": "^4.4.7",
+      "data-fns": "^1.1.0",
       "date-fns": "^4.1.0",
       "dayjs": "^1.11.13",
       "framer-motion": "^12.4.7",

--- a/WarehousePilot_app/frontend/src/components/kpis/throughput-threshold/throughput-graph.jsx
+++ b/WarehousePilot_app/frontend/src/components/kpis/throughput-threshold/throughput-graph.jsx
@@ -1,7 +1,34 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { startOfWeek, format } from 'date-fns';
 
 export default function ThroughputBarGraph({ data, loading, title, isStacked }) {
+  const [groupedData, setGroupedData] = useState([]);
+  
+    /* useEffect - group data by weeks for bar graph */
+    useEffect(() => {
+      const weeklyData = {};
+  
+      // Group data by weeks
+      data.forEach((entry) => {
+        const date = new Date(entry.date);
+        const weekStart = startOfWeek(date, { weekStartsOn: 1 }); // Get the Monday of the week
+        const weekKey = format(weekStart, 'yyyy-MM-dd'); // Use the Monday's date as the key
+  
+        if (!weeklyData[weekKey]) {
+          weeklyData[weekKey] = { date: weekKey, picked: 0, packed: 0, shipped: 0 };
+        }
+  
+        weeklyData[weekKey].picked += entry.picked || 0;
+        weeklyData[weekKey].packed += entry.packed || 0;
+        weeklyData[weekKey].shipped += entry.shipped || 0;
+      });
+  
+      // Convert grouped data into an array and sort by date
+      const formattedData = Object.values(weeklyData).sort((a, b) => new Date(a.date) - new Date(b.date));
+      setGroupedData(formattedData); // Update the grouped data state
+    }, [data]);
+  
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm">
       {loading ? (
@@ -12,7 +39,7 @@ export default function ThroughputBarGraph({ data, loading, title, isStacked }) 
         <>
           {title && <h2 className="text-xl font-semibold mb-4 dark:text-white">{title}</h2>}
           <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+            <BarChart data={groupedData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#4B5563" />
               <XAxis 
                 dataKey="date" 

--- a/WarehousePilot_app/frontend/src/components/kpis/throughput-threshold/throughput-threshold-kpi-preview.jsx
+++ b/WarehousePilot_app/frontend/src/components/kpis/throughput-threshold/throughput-threshold-kpi-preview.jsx
@@ -25,15 +25,16 @@ export default function ThroughputThresholdKpiPreview() {
                 return;
             }
 
-            const response = await axios.get(`${API_BASE_URL}/orders/`, {
+            const response = await axios.get(`${API_BASE_URL}/kpi_dashboard/throughput-threshold/`, {
                 headers: {
                     Authorization: `Bearer ${token}`,
                     "Content-Type": "application/json",
                 },
             });
+            // console.log("Throughput data:", response.data); // Log the response data
 
             const formattedData = response.data.map((item) => ({
-                date: item.date,
+                date: item.day,
                 picked: item.picked,
                 packed: item.packed,
                 shipped: item.shipped,
@@ -76,63 +77,6 @@ export default function ThroughputThresholdKpiPreview() {
     /* useEffect - Fetch data on loading component */
     useEffect(() => {
         fetchData();
-        if (data.length == 0) { //TODO: Remove this if block after backend is implemented 
-            setData([
-                { date: '2025-01-01', picked: 450, packed: 350, shipped: 250 },
-                { date: '2025-01-08', picked: 520, packed: 420, shipped: 320 },
-                { date: '2025-01-15', picked: 580, packed: 480, shipped: 380 },
-                { date: '2025-01-22', picked: 620, packed: 520, shipped: 420 },
-                { date: '2025-01-29', picked: 680, packed: 580, shipped: 480 },
-                { date: '2025-02-05', picked: 720, packed: 620, shipped: 520 },
-                { date: '2025-02-12', picked: 650, packed: 550, shipped: 450 },
-                { date: '2025-02-19', picked: 590, packed: 490, shipped: 390 },
-                { date: '2025-02-26', picked: 630, packed: 530, shipped: 430 },
-                { date: '2025-03-05', picked: 690, packed: 590, shipped: 490 },
-                { date: '2025-03-12', picked: 750, packed: 650, shipped: 550 },
-                { date: '2025-03-19', picked: 820, packed: 720, shipped: 620 },
-                { date: '2025-03-26', picked: 780, packed: 680, shipped: 580 },
-                { date: '2025-04-02', picked: 710, packed: 610, shipped: 510 },
-                { date: '2025-04-09', picked: 670, packed: 570, shipped: 470 },
-                { date: '2025-04-16', picked: 730, packed: 630, shipped: 530 },
-                { date: '2025-04-23', picked: 790, packed: 690, shipped: 590 },
-                { date: '2025-04-30', picked: 850, packed: 750, shipped: 650 },
-                { date: '2025-05-07', picked: 880, packed: 780, shipped: 680 },
-                { date: '2025-05-14', picked: 820, packed: 720, shipped: 620 },
-                { date: '2025-05-21', picked: 760, packed: 660, shipped: 560 },
-                { date: '2025-05-28', picked: 810, packed: 710, shipped: 610 },
-                { date: '2025-06-04', picked: 870, packed: 770, shipped: 670 },
-                { date: '2025-06-11', picked: 920, packed: 820, shipped: 720 },
-                { date: '2025-06-18', picked: 950, packed: 850, shipped: 750 },
-                { date: '2025-06-25', picked: 890, packed: 790, shipped: 690 },
-                { date: '2025-07-02', picked: 830, packed: 730, shipped: 630 },
-                { date: '2025-07-09', picked: 780, packed: 680, shipped: 580 },
-                { date: '2025-07-16', picked: 840, packed: 740, shipped: 640 },
-                { date: '2025-07-23', picked: 910, packed: 810, shipped: 710 },
-                { date: '2025-07-30', picked: 970, packed: 870, shipped: 770 },
-                { date: '2025-08-06', picked: 1020, packed: 920, shipped: 820 },
-                { date: '2025-08-13', picked: 980, packed: 880, shipped: 780 },
-                { date: '2025-08-20', picked: 920, packed: 820, shipped: 720 },
-                { date: '2025-08-27', picked: 870, packed: 770, shipped: 670 },
-                { date: '2025-09-03', picked: 930, packed: 830, shipped: 730 },
-                { date: '2025-09-10', picked: 990, packed: 890, shipped: 790 },
-                { date: '2025-09-17', picked: 1050, packed: 950, shipped: 850 },
-                { date: '2025-09-24', picked: 1100, packed: 1000, shipped: 900 },
-                { date: '2025-10-01', picked: 1020, packed: 920, shipped: 820 },
-                { date: '2025-10-08', picked: 960, packed: 860, shipped: 760 },
-                { date: '2025-10-15', picked: 910, packed: 810, shipped: 710 },
-                { date: '2025-10-22', picked: 970, packed: 870, shipped: 770 },
-                { date: '2025-10-29', picked: 1030, packed: 930, shipped: 830 },
-                { date: '2025-11-05', picked: 1080, packed: 980, shipped: 880 },
-                { date: '2025-11-12', picked: 1120, packed: 1020, shipped: 920 },
-                { date: '2025-11-19', picked: 1050, packed: 950, shipped: 850 },
-                { date: '2025-11-26', picked: 990, packed: 890, shipped: 790 },
-                { date: '2025-12-03', picked: 940, packed: 840, shipped: 740 },
-                { date: '2025-12-10', picked: 1000, packed: 900, shipped: 800 },
-                { date: '2025-12-17', picked: 1070, packed: 970, shipped: 870 },
-                { date: '2025-12-24', picked: 1150, packed: 1050, shipped: 950 },
-                { date: '2025-12-31', picked: 1200, packed: 1100, shipped: 1000 }
-            ]);
-        }
     }, []);
 
     // useEffect - Filter data whenever `data` or `range` changes

--- a/WarehousePilot_app/frontend/src/components/kpis/throughput-threshold/throughtput-threshold-dashboard.jsx
+++ b/WarehousePilot_app/frontend/src/components/kpis/throughput-threshold/throughtput-threshold-dashboard.jsx
@@ -30,7 +30,7 @@ const ThroughputThresholdDashboard = ({ userData }) => {
 
             // Backend API call to get throughput data
             const response = await axios.get(
-                `${API_BASE_URL}/orders/`, //TODO: Change this to throughput path
+                `${API_BASE_URL}/kpi_dashboard/throughput-threshold/`, //TODO: Change this to throughput path
                 {
                     headers: {
                         Authorization: `Bearer ${token}`,
@@ -42,7 +42,7 @@ const ThroughputThresholdDashboard = ({ userData }) => {
             // Format data for ThroughputBarGraph
             const formattedData = response.data.map((item) => {
                 return {
-                    date: item.date,
+                    date: item.day,
                     picked: item.picked,
                     packed: item.packed,
                     shipped: item.shipped,
@@ -68,68 +68,15 @@ const ThroughputThresholdDashboard = ({ userData }) => {
     /* useEffect - fetch data and set loading state */
     useEffect(() => {
         fetchData();
-        if (data.length == 0){ //TODO: Remove this if block after backend is implemented 
-            setData([
-                { date: '2025-01-01', picked: 450, packed: 350, shipped: 250 },
-                { date: '2025-01-08', picked: 520, packed: 420, shipped: 320 },
-                { date: '2025-01-15', picked: 580, packed: 480, shipped: 380 },
-                { date: '2025-01-22', picked: 620, packed: 520, shipped: 420 },
-                { date: '2025-01-29', picked: 680, packed: 580, shipped: 480 },
-                { date: '2025-02-05', picked: 720, packed: 620, shipped: 520 },
-                { date: '2025-02-12', picked: 650, packed: 550, shipped: 450 },
-                { date: '2025-02-19', picked: 590, packed: 490, shipped: 390 },
-                { date: '2025-02-26', picked: 630, packed: 530, shipped: 430 },
-                { date: '2025-03-05', picked: 690, packed: 590, shipped: 490 },
-                { date: '2025-03-12', picked: 750, packed: 650, shipped: 550 },
-                { date: '2025-03-19', picked: 820, packed: 720, shipped: 620 },
-                { date: '2025-03-26', picked: 780, packed: 680, shipped: 580 },
-                { date: '2025-04-02', picked: 710, packed: 610, shipped: 510 },
-                { date: '2025-04-09', picked: 670, packed: 570, shipped: 470 },
-                { date: '2025-04-16', picked: 730, packed: 630, shipped: 530 },
-                { date: '2025-04-23', picked: 790, packed: 690, shipped: 590 },
-                { date: '2025-04-30', picked: 850, packed: 750, shipped: 650 },
-                { date: '2025-05-07', picked: 880, packed: 780, shipped: 680 },
-                { date: '2025-05-14', picked: 820, packed: 720, shipped: 620 },
-                { date: '2025-05-21', picked: 760, packed: 660, shipped: 560 },
-                { date: '2025-05-28', picked: 810, packed: 710, shipped: 610 },
-                { date: '2025-06-04', picked: 870, packed: 770, shipped: 670 },
-                { date: '2025-06-11', picked: 920, packed: 820, shipped: 720 },
-                { date: '2025-06-18', picked: 950, packed: 850, shipped: 750 },
-                { date: '2025-06-25', picked: 890, packed: 790, shipped: 690 },
-                { date: '2025-07-02', picked: 830, packed: 730, shipped: 630 },
-                { date: '2025-07-09', picked: 780, packed: 680, shipped: 580 },
-                { date: '2025-07-16', picked: 840, packed: 740, shipped: 640 },
-                { date: '2025-07-23', picked: 910, packed: 810, shipped: 710 },
-                { date: '2025-07-30', picked: 970, packed: 870, shipped: 770 },
-                { date: '2025-08-06', picked: 1020, packed: 920, shipped: 820 },
-                { date: '2025-08-13', picked: 980, packed: 880, shipped: 780 },
-                { date: '2025-08-20', picked: 920, packed: 820, shipped: 720 },
-                { date: '2025-08-27', picked: 870, packed: 770, shipped: 670 },
-                { date: '2025-09-03', picked: 930, packed: 830, shipped: 730 },
-                { date: '2025-09-10', picked: 990, packed: 890, shipped: 790 },
-                { date: '2025-09-17', picked: 1050, packed: 950, shipped: 850 },
-                { date: '2025-09-24', picked: 1100, packed: 1000, shipped: 900 },
-                { date: '2025-10-01', picked: 1020, packed: 920, shipped: 820 },
-                { date: '2025-10-08', picked: 960, packed: 860, shipped: 760 },
-                { date: '2025-10-15', picked: 910, packed: 810, shipped: 710 },
-                { date: '2025-10-22', picked: 970, packed: 870, shipped: 770 },
-                { date: '2025-10-29', picked: 1030, packed: 930, shipped: 830 },
-                { date: '2025-11-05', picked: 1080, packed: 980, shipped: 880 },
-                { date: '2025-11-12', picked: 1120, packed: 1020, shipped: 920 },
-                { date: '2025-11-19', picked: 1050, packed: 950, shipped: 850 },
-                { date: '2025-11-26', picked: 990, packed: 890, shipped: 790 },
-                { date: '2025-12-03', picked: 940, packed: 840, shipped: 740 },
-                { date: '2025-12-10', picked: 1000, packed: 900, shipped: 800 },
-                { date: '2025-12-17', picked: 1070, packed: 970, shipped: 870 },
-                { date: '2025-12-24', picked: 1150, packed: 1050, shipped: 950 },
-                { date: '2025-12-31', picked: 1200, packed: 1100, shipped: 1000 }
-            ]);
-            setDonutChartData(formatDataForDonutChart({ date: '2025-03-27', picked: 700, packed: 600, shipped: 500 }));
-        }
-        else 
-            setDonutChartData(formatDataForDonutChart(data[data.length - 1]));
         setLoading(false);
     }, []);
+
+    // Had to separate this useEffect from the one above to avoid async issues
+    useEffect(() => {
+        if (data.length > 0) {
+            setDonutChartData(formatDataForDonutChart(data[data.length - 1]));
+        }
+    }, [data]); // Run this effect whenever `data` changes
 
     /* handleViewDetails: navigate to KPI page */
     const handleViewDetails = () => {


### PR DESCRIPTION
This PR implements the throughput backend. It retrieves the throughput for the past year and formats it according to the frontend UI. For screenshots after the backend has been implemented, please refer to the github issue #253.