### PR TITLE
Modifying settings.py to allow specific frontend URLs

### DIFF
--- a/WarehousePilot_app/backend/backend/settings.py
+++ b/WarehousePilot_app/backend/backend/settings.py
@@ -185,7 +185,13 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
 }
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOWED_ORIGINS = [
+    os.getenv('FRONTEND_URL').rstrip('/'),  # Frontend domain
+    "http://localhost:5173",  # Development URL (default)
+    "http://127.0.0.1:5173" # Localhost IP ^
+]
+CORS_ALLOW_ALL_ORIGINS = False 
+
 AUTH_USER_MODEL = 'auth_app.users'
 
 

--- a/WarehousePilot_app/backend/backend/settings.py
+++ b/WarehousePilot_app/backend/backend/settings.py
@@ -185,8 +185,9 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
 }
 
+FRONTEND_URL = os.getenv('FRONTEND_URL', 'http://localhost:5173').rstrip('/')
 CORS_ALLOWED_ORIGINS = [
-    os.getenv('FRONTEND_URL').rstrip('/'),  # Frontend domain
+    FRONTEND_URL,  # Frontend domain
     "http://localhost:5173",  # Development URL (default)
     "http://127.0.0.1:5173" # Localhost IP ^
 ]

--- a/WarehousePilot_app/backend/backend/settings.py
+++ b/WarehousePilot_app/backend/backend/settings.py
@@ -185,10 +185,10 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
 }
 
-FRONTEND_URL = os.getenv('FRONTEND_URL', 'http://localhost:5173').rstrip('/')
+FRONTEND_URL = os.getenv('FRONTEND_URL', "https://inventorypilot-82re.onrender.com").rstrip('/')
 CORS_ALLOWED_ORIGINS = [
-    FRONTEND_URL,  # Frontend domain
-    "https://inventorypilot-82re.onrender.com/",  # Production URL
+    FRONTEND_URL,  # Production URL
+    "https://inventorypilot-82re.onrender.com",  # Production URL ^
     "http://localhost:5173",  # Development URL (default)
     "http://127.0.0.1:5173" # Localhost IP ^
 ]

--- a/WarehousePilot_app/backend/backend/settings.py
+++ b/WarehousePilot_app/backend/backend/settings.py
@@ -188,6 +188,7 @@ SIMPLE_JWT = {
 FRONTEND_URL = os.getenv('FRONTEND_URL', 'http://localhost:5173').rstrip('/')
 CORS_ALLOWED_ORIGINS = [
     FRONTEND_URL,  # Frontend domain
+    "https://inventorypilot-82re.onrender.com/",  # Production URL
     "http://localhost:5173",  # Development URL (default)
     "http://127.0.0.1:5173" # Localhost IP ^
 ]


### PR DESCRIPTION
Added CORS_ALLOWED_ORIGINS to allow for url creation for password reset and not crash our hosted website